### PR TITLE
Fix RSS feed XML declaration

### DIFF
--- a/resources/views/pages/feed/xml.blade.php
+++ b/resources/views/pages/feed/xml.blade.php
@@ -1,4 +1,4 @@
-<?php echo '<?xml version="1.0" encoding="UTF-8"?>'; ?>
+<?= '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL ?>
 <rss version="2.0"
      xmlns:content="http://purl.org/rss/1.0/modules/content/"
      xmlns:atom="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
## Summary
- Fixes the XML declaration in the RSS feed template
- Uses proper PHP syntax (`<?=`) for outputting XML declarations in Laravel Blade
- Resolves the XML parsing error seen in the validator

## Test plan
1. Visit /feed.xml to see the RSS feed without errors
2. Verify feed now passes XML feed validators
3. Confirm the tests are passing

Based on best practices for generating XML in Laravel Blade templates.

🤖 Generated with [Claude Code](https://claude.ai/code)