### PR TITLE
Create client_email_bodies migration

### DIFF
--- a/database/migrations/2025_05_13_030914_create_client_email_bodies_table.php
+++ b/database/migrations/2025_05_13_030914_create_client_email_bodies_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('client_email_bodies', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('client_email_id')->constrained()->cascadeOnDelete();
+            $table->longText('html_content')->nullable();
+            $table->longText('text_content')->nullable();
+            $table->timestamps();
+
+            // Index for faster queries
+            $table->index('client_email_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('client_email_bodies');
+    }
+};

--- a/database/migrations/README.md
+++ b/database/migrations/README.md
@@ -1,0 +1,75 @@
+# Gmail Integration Migrations
+
+This document outlines the database schema for the Gmail integration feature.
+
+## Migration Order
+
+1. `2025_05_11_235024_create_gmail_client_table.php` - Core table for email metadata
+2. `2025_05_12_002442_create_gmail_tokens_table.php` - Stores OAuth tokens for Gmail API
+3. `2025_05_13_030914_create_client_email_bodies_table.php` - Stores email body content
+4. `create_client_email_attachments_migration` (Upcoming) - Stores email attachments
+
+## Schema Design
+
+### client_emails
+Stores essential metadata about emails associated with clients.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | bigint | Primary key |
+| client_id | bigint | Foreign key to clients table |
+| gmail_message_id | string | Unique ID from Gmail API |
+| subject | string | Email subject line |
+| from | string | Sender email address |
+| to | json | Recipient email addresses |
+| cc | json | Carbon copy recipients |
+| bcc | json | Blind carbon copy recipients |
+| snippet | text | Preview text |
+| body | longtext | Full email content (HTML) |
+| label_ids | json | Gmail labels for organization |
+| raw_payload | json | Raw message data from Gmail API |
+| email_date | timestamp | When email was sent/received |
+| synchronized_at | timestamp | When email was synced |
+| created_at | timestamp | Record creation timestamp |
+| updated_at | timestamp | Record update timestamp |
+
+**Indexes:**
+- `gmail_message_id` - Prevents duplicate emails
+- `client_id` with `received_at` - For efficient client email timeline queries
+
+### gmail_tokens
+Stores OAuth tokens for Gmail API authentication.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | bigint | Primary key |
+| user_id | bigint | Foreign key to users table |
+| access_token | text | OAuth access token |
+| refresh_token | text | OAuth refresh token |
+| expires_at | timestamp | Token expiration time |
+| created_at | timestamp | Record creation timestamp |
+| updated_at | timestamp | Record update timestamp |
+
+### client_email_bodies
+Stores email body content separately for performance optimization.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | bigint | Primary key |
+| client_email_id | bigint | Foreign key to client_emails table |
+| html_content | longtext | HTML version of email body |
+| text_content | longtext | Plain text version of email body |
+| created_at | timestamp | Record creation timestamp |
+| updated_at | timestamp | Record update timestamp |
+
+**Indexes:**
+- `client_email_id` - For efficient lookups
+
+## Design Rationale
+
+The design separates email content (bodies) and attachments into separate tables for:
+
+1. **Performance** - Prevents loading large content when only metadata is needed
+2. **Storage efficiency** - Allows appropriate column types for different content
+3. **Query optimization** - Allows selective loading of only needed components
+4. **Scalability** - Handles large volumes of emails with attachments efficiently

--- a/tests/Feature/ClientEmailBodyTest.php
+++ b/tests/Feature/ClientEmailBodyTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Models\Client;
+use App\Models\ClientEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+test('client_email_bodies table has expected columns', function () {
+    // Run the migrations
+    $this->assertTrue(Schema::hasTable('client_email_bodies'));
+
+    // Check for the expected columns
+    $this->assertTrue(Schema::hasColumns('client_email_bodies', [
+        'id',
+        'client_email_id',
+        'html_content',
+        'text_content',
+        'created_at',
+        'updated_at',
+    ]));
+});
+
+test('client_email_bodies table has correct foreign key constraint', function () {
+    // Create a client and email
+    $client = Client::factory()->create();
+    $clientEmail = ClientEmail::factory()->create([
+        'client_id' => $client->id,
+    ]);
+
+    // Insert a record into client_email_bodies using DB facade
+    $bodyId = DB::table('client_email_bodies')->insertGetId([
+        'client_email_id' => $clientEmail->id,
+        'html_content'    => '<p>This is an HTML email.</p>',
+        'text_content'    => 'This is a plain text email.',
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    $this->assertNotNull($bodyId);
+
+    // Test cascade delete when parent email is deleted
+    $clientEmail->delete();
+
+    $this->assertDatabaseMissing('client_email_bodies', [
+        'id' => $bodyId,
+    ]);
+});
+
+test('multiple formats of email content can be stored', function () {
+    // Create a client and email
+    $client = Client::factory()->create();
+    $clientEmail = ClientEmail::factory()->create([
+        'client_id' => $client->id,
+    ]);
+
+    // Create email body with both HTML and text content
+    $bodyId = DB::table('client_email_bodies')->insertGetId([
+        'client_email_id' => $clientEmail->id,
+        'html_content'    => '<div><h1>Test Email</h1><p>This is a <strong>formatted</strong> email.</p></div>',
+        'text_content'    => "Test Email\n\nThis is a formatted email.",
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    // Verify the data was stored correctly
+    $emailBody = DB::table('client_email_bodies')->find($bodyId);
+
+    $this->assertEquals('<div><h1>Test Email</h1><p>This is a <strong>formatted</strong> email.</p></div>', $emailBody->html_content);
+    $this->assertEquals("Test Email\n\nThis is a formatted email.", $emailBody->text_content);
+});
+
+test('email body content can be null', function () {
+    // Create a client and email
+    $client = Client::factory()->create();
+    $clientEmail = ClientEmail::factory()->create([
+        'client_id' => $client->id,
+    ]);
+
+    // Create email body with only HTML content
+    $htmlOnlyId = DB::table('client_email_bodies')->insertGetId([
+        'client_email_id' => $clientEmail->id,
+        'html_content'    => '<p>HTML only email</p>',
+        'text_content'    => null,
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    // Create another with only text content
+    $textOnlyId = DB::table('client_email_bodies')->insertGetId([
+        'client_email_id' => $clientEmail->id,
+        'html_content'    => null,
+        'text_content'    => 'Text only email',
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    // Verify the data was stored correctly
+    $htmlOnly = DB::table('client_email_bodies')->find($htmlOnlyId);
+    $textOnly = DB::table('client_email_bodies')->find($textOnlyId);
+
+    $this->assertEquals('<p>HTML only email</p>', $htmlOnly->html_content);
+    $this->assertNull($htmlOnly->text_content);
+
+    $this->assertNull($textOnly->html_content);
+    $this->assertEquals('Text only email', $textOnly->text_content);
+});


### PR DESCRIPTION
## Summary
- Created database migration for client_email_bodies table to store HTML and plain text email content
- Added comprehensive README documenting Gmail integration database schema
- Implemented foreign key constraints with cascade delete for data integrity
- Created tests to verify table structure and data handling

## Test plan
- Run `php artisan test tests/Feature/ClientEmailBodyTest.php` to verify:
  - Table and columns are created correctly
  - Foreign key constraints work as expected with cascade delete
  - Both HTML and plain text content can be stored properly
  - Nullable fields work as expected

This PR is the second step in the Gmail integration feature, providing storage for email body content separate from metadata for performance optimization.

Closes #205