### PR TITLE
🚨 HOTFIX: Gmail Labels Livewire Serialization Critical Fix - P0

### DIFF
--- a/app/Filament/Pages/GmailLabelsPage.php
+++ b/app/Filament/Pages/GmailLabelsPage.php
@@ -9,6 +9,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Illuminate\Support\Facades\Log;
 
 class GmailLabelsPage extends Page implements HasForms
 {
@@ -83,37 +84,60 @@ class GmailLabelsPage extends Page implements HasForms
             $gmailClient = $user->getGmailClient();
             $gmailLabels = $gmailClient->listLabels();
 
+            // CRITICAL FIX: Enhanced Livewire serialization handling
             $this->labels = $gmailLabels->map(function ($label) {
+                // Ensure all data is properly serializable for Livewire
                 if (is_array($label)) {
                     return [
-                        'id'             => $label['id'] ?? '',
-                        'name'           => $label['name'] ?? '',
-                        'type'           => $label['type'] ?? 'user',
-                        'messagesTotal'  => $label['messagesTotal'] ?? 0,
-                        'messagesUnread' => $label['messagesUnread'] ?? 0,
-                        'threadsTotal'   => $label['threadsTotal'] ?? 0,
-                        'threadsUnread'  => $label['threadsUnread'] ?? 0,
+                        'id'             => (string) ($label['id'] ?? ''),
+                        'name'           => (string) ($label['name'] ?? ''),
+                        'type'           => (string) ($label['type'] ?? 'user'),
+                        'messagesTotal'  => (int) ($label['messagesTotal'] ?? 0),
+                        'messagesUnread' => (int) ($label['messagesUnread'] ?? 0),
+                        'threadsTotal'   => (int) ($label['threadsTotal'] ?? 0),
+                        'threadsUnread'  => (int) ($label['threadsUnread'] ?? 0),
                     ];
                 }
 
+                // Handle object conversion with explicit type casting
                 return [
-                    'id'             => $label->id,
-                    'name'           => $label->name,
-                    'type'           => $label->type ?? 'user',
-                    'messagesTotal'  => $label->messagesTotal ?? 0,
-                    'messagesUnread' => $label->messagesUnread ?? 0,
-                    'threadsTotal'   => $label->threadsTotal ?? 0,
-                    'threadsUnread'  => $label->threadsUnread ?? 0,
+                    'id'             => (string) ($label->id ?? ''),
+                    'name'           => (string) ($label->name ?? ''),
+                    'type'           => (string) ($label->type ?? 'user'),
+                    'messagesTotal'  => (int) ($label->messagesTotal ?? 0),
+                    'messagesUnread' => (int) ($label->messagesUnread ?? 0),
+                    'threadsTotal'   => (int) ($label->threadsTotal ?? 0),
+                    'threadsUnread'  => (int) ($label->threadsUnread ?? 0),
                 ];
-            })->toArray();
+            })->toArray(); // Ensure final result is a plain array
+
+            // Verify serialization compatibility
+            $this->validateLabelsData();
 
             $this->filterLabels();
+
+            Log::info('Gmail labels loaded successfully', [
+                'total_labels' => count($this->labels),
+                'system_count' => collect($this->labels)->where('type', 'system')->count(),
+                'user_count'   => collect($this->labels)->where('type', 'user')->count()
+            ]);
+
         } catch (\Exception $e) {
+            Log::error('Gmail labels loading failed', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
             Notification::make()
                 ->title('Error fetching labels')
-                ->body($e->getMessage())
+                ->body('Failed to load Gmail labels: ' . $e->getMessage())
                 ->danger()
                 ->send();
+
+            // Fallback to empty arrays to prevent further issues
+            $this->labels = [];
+            $this->systemLabels = [];
+            $this->userLabels = [];
 
             $this->redirect(GmailIntegrationPage::getUrl());
         }
@@ -121,18 +145,49 @@ class GmailLabelsPage extends Page implements HasForms
 
     public function filterLabels()
     {
-        $filtered = collect($this->labels);
+        try {
+            $filtered = collect($this->labels);
 
-        // Filter by search term
-        if (!empty($this->searchTerm)) {
-            $filtered = $filtered->filter(function ($label) {
-                return str_contains(strtolower($label['name']), strtolower($this->searchTerm));
-            });
+            // Filter by search term
+            if (!empty($this->searchTerm)) {
+                $filtered = $filtered->filter(function ($label) {
+                    return str_contains(strtolower($label['name'] ?? ''), strtolower($this->searchTerm));
+                });
+            }
+
+            // CRITICAL FIX: Ensure filtered data is properly serializable
+            $this->systemLabels = $filtered
+                ->where('type', 'system')
+                ->values()
+                ->map(function ($label) {
+                    return $this->sanitizeLabelForLivewire($label);
+                })
+                ->toArray();
+
+            $this->userLabels = $filtered
+                ->where('type', 'user')
+                ->values()
+                ->map(function ($label) {
+                    return $this->sanitizeLabelForLivewire($label);
+                })
+                ->toArray();
+
+            Log::info('Labels filtered successfully', [
+                'search_term'    => $this->searchTerm,
+                'system_labels'  => count($this->systemLabels),
+                'user_labels'    => count($this->userLabels)
+            ]);
+
+        } catch (\Exception $e) {
+            Log::error('Label filtering failed', [
+                'error' => $e->getMessage(),
+                'search_term' => $this->searchTerm
+            ]);
+
+            // Fallback to prevent crashes
+            $this->systemLabels = [];
+            $this->userLabels = [];
         }
-
-        // Separate system and user labels
-        $this->systemLabels = $filtered->where('type', 'system')->values()->toArray();
-        $this->userLabels = $filtered->where('type', 'user')->values()->toArray();
     }
 
     public function selectLabelType(string $type)
@@ -142,9 +197,18 @@ class GmailLabelsPage extends Page implements HasForms
 
     public function viewLabelMessages(string $labelId, string $labelName)
     {
+        // Sanitize parameters before redirect
+        $cleanLabelId = filter_var($labelId, FILTER_SANITIZE_STRING);
+        $cleanLabelName = filter_var($labelName, FILTER_SANITIZE_STRING);
+
+        Log::info('Redirecting to messages page', [
+            'label_id' => $cleanLabelId,
+            'label_name' => $cleanLabelName
+        ]);
+
         // Redirect to messages page with label filter
         return redirect()->route('filament.admin.pages.gmail-messages-page', [
-            'selectedLabel' => $labelId
+            'selectedLabel' => $cleanLabelId
         ]);
     }
 
@@ -161,5 +225,109 @@ class GmailLabelsPage extends Page implements HasForms
                 ->color('warning')
                 ->action(fn () => $this->loadLabels()),
         ];
+    }
+
+    /**
+     * CRITICAL FIX: Sanitize label data for Livewire compatibility
+     */
+    private function sanitizeLabelForLivewire(array $label): array
+    {
+        return [
+            'id'             => (string) ($label['id'] ?? ''),
+            'name'           => (string) ($label['name'] ?? ''),
+            'type'           => (string) ($label['type'] ?? 'user'),
+            'messagesTotal'  => (int) ($label['messagesTotal'] ?? 0),
+            'messagesUnread' => (int) ($label['messagesUnread'] ?? 0),
+            'threadsTotal'   => (int) ($label['threadsTotal'] ?? 0),
+            'threadsUnread'  => (int) ($label['threadsUnread'] ?? 0),
+        ];
+    }
+
+    /**
+     * CRITICAL FIX: Validate that labels data is properly serializable
+     */
+    private function validateLabelsData(): void
+    {
+        foreach ($this->labels as $index => $label) {
+            if (!is_array($label)) {
+                Log::warning("Non-array label found at index {$index}", [
+                    'label_type' => gettype($label),
+                    'label_data' => is_object($label) ? get_class($label) : $label
+                ]);
+
+                // Convert to array if it's an object
+                if (is_object($label)) {
+                    $this->labels[$index] = $this->sanitizeLabelForLivewire((array) $label);
+                } else {
+                    // Remove invalid entries
+                    unset($this->labels[$index]);
+                }
+            }
+
+            // Ensure all required fields exist and are proper types
+            if (isset($this->labels[$index])) {
+                $this->labels[$index] = $this->sanitizeLabelForLivewire($this->labels[$index]);
+            }
+        }
+
+        // Re-index array to prevent gaps
+        $this->labels = array_values($this->labels);
+
+        Log::info('Labels data validation completed', [
+            'total_labels' => count($this->labels)
+        ]);
+    }
+
+    /**
+     * CRITICAL FIX: Handle potential serialization issues during Livewire updates
+     */
+    public function dehydrate()
+    {
+        // Ensure all properties are properly serializable before Livewire dehydration
+        try {
+            $this->labels = array_map([$this, 'sanitizeLabelForLivewire'], $this->labels);
+            $this->systemLabels = array_map([$this, 'sanitizeLabelForLivewire'], $this->systemLabels);
+            $this->userLabels = array_map([$this, 'sanitizeLabelForLivewire'], $this->userLabels);
+        } catch (\Exception $e) {
+            Log::error('Dehydration error in GmailLabelsPage', [
+                'error' => $e->getMessage()
+            ]);
+
+            // Reset to safe state
+            $this->labels = [];
+            $this->systemLabels = [];
+            $this->userLabels = [];
+        }
+    }
+
+    /**
+     * CRITICAL FIX: Handle potential serialization issues during Livewire hydration
+     */
+    public function hydrate()
+    {
+        // Ensure all properties are properly formatted after Livewire hydration
+        try {
+            if (!is_array($this->labels)) {
+                $this->labels = [];
+            }
+            if (!is_array($this->systemLabels)) {
+                $this->systemLabels = [];
+            }
+            if (!is_array($this->userLabels)) {
+                $this->userLabels = [];
+            }
+
+            // Validate data integrity
+            $this->validateLabelsData();
+        } catch (\Exception $e) {
+            Log::error('Hydration error in GmailLabelsPage', [
+                'error' => $e->getMessage()
+            ]);
+
+            // Reset to safe state
+            $this->labels = [];
+            $this->systemLabels = [];
+            $this->userLabels = [];
+        }
     }
 }


### PR DESCRIPTION
## 🚨 CRITICAL HOTFIX - Gmail Labels Livewire Serialization

### **Problem**
Gmail Labels page completely broken due to Livewire serialization errors. Objects being passed instead of arrays causing crashes.

### **Root Cause**
Gmail API returns objects that cannot be properly serialized by Livewire, causing the entire labels page to fail with serialization exceptions.

### **Solution**
✅ **Enhanced object-to-array conversion** with explicit type casting  
✅ **Added data validation** to prevent invalid objects from breaking serialization  
✅ **Implemented Livewire lifecycle hooks** (dehydrate/hydrate) for proper state management  
✅ **Comprehensive error handling** with fallback mechanisms  
✅ **Improved logging** for better debugging and monitoring  

### **Technical Changes**
- **`sanitizeLabelForLivewire()`** - Ensures all data is properly type-cast
- **`validateLabelsData()`** - Validates serialization compatibility  
- **`dehydrate()/hydrate()`** - Proper Livewire state management
- **Enhanced error handling** - Prevents crashes with graceful fallbacks

### **Impact**
- 🔧 **FIXES:** Gmail Labels page crashes (Critical P0 issue)
- 🛡️ **PREVENTS:** Future Livewire serialization errors
- 📈 **IMPROVES:** Overall page stability and reliability
- 🎯 **ENHANCES:** Error tracking and debugging capabilities

### **Testing Completed**
- [x] Gmail labels page loading functionality
- [x] Label filtering and search operations  
- [x] Label selection and navigation behavior
- [x] Browser console - no serialization errors
- [x] Livewire state transitions work properly

### **Priority**
🔥 **EMERGENCY MERGE REQUIRED** - Critical functionality restored

**Ready for immediate deployment** ✅